### PR TITLE
Fix: Compiles on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # arrogant
 Fully conformant HTML5 dom library with CSS4 selectors. Based on [Modest](https://github.com/lexborisov/Modest).
 
-Tested on Linux. Should work fine on OSX. Never tried on Windows. 
+Tested on Linux. Should work fine on OSX and Windows. 
 
 # prerequisites: how to build & install modest
 

--- a/source/arrogant/c/modest.d
+++ b/source/arrogant/c/modest.d
@@ -1544,7 +1544,13 @@ extern(C)
 
 
     int fflush_unlocked(FILE*) @nogc nothrow;
-    alias size_t = c_ulong;
+    version (Windows)
+    {
+    }
+    else
+    {
+        alias size_t = c_ulong;
+    }
 
 
     alias blkcnt_t = c_long;


### PR DESCRIPTION
Compiles on Windows.

Only tested with Windows 10 `1909`, dmd `v2.087.1`, dub `v1.16.0`